### PR TITLE
Update/change default spectrogram scheme

### DIFF
--- a/docs/src/phon_spectrogram.md
+++ b/docs/src/phon_spectrogram.md
@@ -14,7 +14,7 @@ s = vec(s)
 phonspec(s, fs)
 ```
 
-A color scheme more similar to the Praat grayscale can be achieved using the `col` argument:
+A color scheme more similar to the Praat grayscale can be achieved using the `col` argument and the `:gist_yarg` color scheme. These spectrograms are created using the `heatmap` function from `Plots.jl`, so [any color scheme available in the Plots package](https://docs.juliaplots.org/stable/generated/colorschemes/) can be used, though not all of them produce legible spectrograms.
 
 ```@example
 using Phonetics # hide
@@ -22,8 +22,7 @@ using WAV # hide
 s, fs = wavread("assets/iwantaspectrogram.wav") # hide
 s = vec(s) # hide
 using Plots
-rev_grays = reverse(cgrad(:grays))
-phonspec(s, fs, col=rev_grays)
+phonspec(s, fs, col=:gist_yarg)
 ```
 
 A narrowband style spectrogram can be plotted using the `style` argument:
@@ -36,7 +35,7 @@ s = vec(s) # hide
 phonspec(s, fs, style=:narrowband)
 ```
 
-And, the pre-emphasis can be disabled by passing in a value of 0 for the `pre_emph` argument:
+And, the pre-emphasis can be disabled by passing in a value of 0 for the `pre_emph` argument. Pre-emphasis will boost the prevalence of the higher frequencies in comparison to the lower frequencies.
 
 ```@example
 using Phonetics # hide

--- a/docs/src/phon_spectrogram.md
+++ b/docs/src/phon_spectrogram.md
@@ -22,7 +22,7 @@ using WAV # hide
 s, fs = wavread("assets/iwantaspectrogram.wav") # hide
 s = vec(s) # hide
 using Plots
-phonspec(s, fs, col=:gist_yarg)
+phonspec(s, fs, col=:binary)
 ```
 
 A narrowband style spectrogram can be plotted using the `style` argument:

--- a/src/phon_spectrogram.jl
+++ b/src/phon_spectrogram.jl
@@ -20,7 +20,7 @@ Args
 * `dbr` The dynamic range; all frequencies that are `dbr` decibels quieter than the loudest frequency will not be displayed
 * `size` Size of plot in pixels; passed to `heatmap` call
 """
-function phonspec(s::Vector, fs; pre_emph=0.97, col=:magma, style=:broadband, dbr=55, size=(600, 400))
+function phonspec(s::Vector, fs; pre_emph=0.97, col=:inferno, style=:broadband, dbr=55, size=(600, 400))
 	pre_emph_filt = PolynomialRatio([1, -pre_emph], [1])
 	s = filt(pre_emph_filt, s)
 	if style == :broadband


### PR DESCRIPTION
Updates the default spectrogram scheme to `:inferno` instead of `:magma`. The inferno color scheme provides slightly better contrast in comparison to magma.