### PR TITLE
Resolve qt5-default error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: julia-actions/setup-julia@v1
         with:
           version: ${{ matrix.julia-version }}
-      - run: sudo apt-get update; sudo apt-get install python3-scipy qt5-default
+      - run: sudo apt-get update; sudo apt-get install python3-scipy
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1


### PR DESCRIPTION
qt5-default was in the apt instructions and is no longer in Ubuntu repos. Trying to resolve this issue by first just removing the dependency.