### PR TITLE
Add vowelhull and hullarea functions

### DIFF
--- a/docs/src/vowelplot.md
+++ b/docs/src/vowelplot.md
@@ -62,6 +62,41 @@ nothing # hide
 
 The labels are offset from the mean value a bit so as to not cover up the marker showing where the mean value is.
 
+## Convex hulls
+
+Convex hulls can be added to a plot using the `vowelhull` plotting function.
+
+```@example
+using Phonetics # hide
+using Plots # hide
+data = generateFormants(30, gender=["w"], seed=56) # hide
+vowelhull(data.f1, data.f2, label="Vowel space")
+savefig("hull_vowel_plot.svg") # hide
+nothing # hide
+```
+
+A hull can be plotted on top of a scatter using `vowelhull!`.
+
+```@example
+using Phonetics # hide
+using Plots # hide
+data = generateFormants(30, gender=["w"], seed=56) # hide
+vowelplot(data.f1, data.f2, data.vowel, ell=true,
+  meansOnly=true, addLabels=true, xlab="F1 (Hz)", ylab="F2 (Hz)")
+ vowelhull!(data.f1, data.f2, label="")
+savefig("means_only_ellipse_vowel_plot.svg") # hide
+nothing # hide
+```
+
+The area of a convex hull can be calculated using `hullarea`.
+
+```@example
+using Phonetics # hide
+using Plots # hide
+data = generateFormants(30, gender=["w"], seed=56) # hide
+hullarea(data.f1, data.f2)
+```
+
 ## Function documentation
 
 ```@docs
@@ -70,6 +105,14 @@ vowelplot
 
 ```@docs
 ellipsePts
+```
+
+```@docs
+vowelhull
+```
+
+```@docs
+hullarea
 ```
 
 ## References

--- a/src/Phonetics.jl
+++ b/src/Phonetics.jl
@@ -18,7 +18,7 @@ include("normalize.jl")
 export neareyE, neareyI, lobanov, formantWiseLogMean, nearey1, logmeanI, formantBlindLogMean, nearey2, logmeanE
 
 include("vowelplot.jl")
-export vowelplot, ellipsePts
+export vowelplot, ellipsePts, vowelhull, hullarea
 
 include("util.jl")
 export generateFormants

--- a/src/vowelplot.jl
+++ b/src/vowelplot.jl
@@ -115,3 +115,49 @@ function ellipsePts(f1, f2; percent=0.67, nPoints=500)
   pts[2,:] .+= mean(f2)
   return Array(pts')
 end
+
+"""
+    vowelhull(f1, f2; kw...)
+
+Plot a convex hull around the F1-F2 space specified with `f1` and `f2`. Accepts standard keyword arguments for plots from `Plots.jl`.
+
+Args
+======
+
+* `f1` The F1 values, or otherwise the values to plot on the x-axis
+* `f2` The F2 values, or otherwise the values to plot on the y-axis
+"""
+vowelhull
+
+@userplot VowelHull
+@recipe function f(v::VowelHull)
+
+	f1, f2 = v.args
+	d = DataFrame(f1=f1, f2=f2)
+	
+	h = chull([d.f1 d.f2])
+	
+	idxs = [h.vertices; h.vertices[1]]
+	d_sub = d[idxs, :]
+	
+	
+	@series begin
+		seriestype = :scatter
+		[d_sub.f1], [d_sub.f2]
+	end
+end
+
+
+"""
+    hullarea(f1, f2)
+	
+Returns the area of the convex hull around the (by default) F1-F2 space specified by `f1` and `f2`. Areas/volumes of hulls in other spaces, such as speicfied by F1-F2-F3 or F1-F2-duration can also be calculated.
+
+Args
+======
+
+* `f1` The F1 values, or otherwise the first variable/dimension for the hull
+* `f2` The F2 values, or otherwise the second variable/dimension for the hull
+* `x...` Additional variable to include in the hull, such as duration or F3
+"""
+hullarea(f1, f2, x...) = chull(hcat(f1, f2, x...)).area


### PR DESCRIPTION
Adds
* `vowelhull` which plots a convex hull based on F1 and F2 values (or whatever other values a user wants)
* `hullarea` which calculates the convex hull area for the passed in arguments (F1 and F2 by default, but can accept an arbitrary number of arguments/dimensions)